### PR TITLE
feat: add Jupyter quick launcher for easy restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,20 @@ For detailed features, see [Features Documentation](docs/features.md).
 ## 🚀 Quick Start
 
 ### 📓 Interactive Jupyter Demos
-Experience RusTorch in your browser with zero setup:
 
-**🚀 Quick Launcher (Returning Users)**: `./start_jupyter_quick.sh` - Interactive menu for fast restarts
+**🚀 First Time Setup** - Choose your preferred demo and run the setup command:
 
-| Demo Type | Initial Setup Command | Description |
-|-----------|----------------------|-------------|
+| Demo Type | Setup Command | Description |
+|-----------|---------------|-------------|
 | 🐍 **Python** | `./start_jupyter.sh` | Standard CPU-based ML demos |
 | ⚡ **WebGPU** | `./start_jupyter_webgpu.sh` | Browser GPU acceleration (Chrome) |
 | 🦀 **Rust Kernel** | `./quick_start_rust_kernel.sh` | Native Rust in Jupyter |
-| 🌐 **Online** | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/JunSuzukiJapan/rustorch/main?urlpath=lab) | Run immediately in browser |
+| 🌐 **Online** | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/JunSuzukiJapan/rustorch/main?urlpath=lab) | No setup needed - run in browser |
+
+**⚡ Quick Restart** - After initial setup, use the fast launcher:
+```bash
+./start_jupyter_quick.sh  # Interactive menu for returning users
+```
 
 📚 **Detailed Setup**: [Complete Jupyter Guide](README_JUPYTER.md) | [日本語ガイド](docs/jupyter-wasm-guide.md)
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ For detailed features, see [Features Documentation](docs/features.md).
 ### 📓 Interactive Jupyter Demos
 Experience RusTorch in your browser with zero setup:
 
-| Demo Type | Launch Command | Description |
-|-----------|----------------|-------------|
+**🚀 Quick Launcher (Returning Users)**: `./start_jupyter_quick.sh` - Interactive menu for fast restarts
+
+| Demo Type | Initial Setup Command | Description |
+|-----------|----------------------|-------------|
 | 🐍 **Python** | `./start_jupyter.sh` | Standard CPU-based ML demos |
 | ⚡ **WebGPU** | `./start_jupyter_webgpu.sh` | Browser GPU acceleration (Chrome) |
 | 🦀 **Rust Kernel** | `./quick_start_rust_kernel.sh` | Native Rust in Jupyter |

--- a/start_jupyter_quick.sh
+++ b/start_jupyter_quick.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# RusTorch Jupyter Quick Launcher
+# 簡単Jupyter起動スクリプト
+
+set -e
+
+echo "🚀 RusTorch Jupyter Quick Launcher"
+echo "🚀 RusTorch Jupyter 簡単起動"
+echo ""
+
+# Function to check if setup exists
+check_setup() {
+    local setup_type=$1
+    case $setup_type in
+        "python")
+            [ -d ".venv" ] && [ -f ".venv/bin/activate" ]
+            ;;
+        "webgpu")
+            [ -d "pkg-webgpu" ] && [ -f "pkg-webgpu/rustorch.js" ]
+            ;;
+        "rust")
+            command -v evcxr_jupyter >/dev/null 2>&1
+            ;;
+    esac
+}
+
+# Display menu
+echo "📓 Available Jupyter Demos:"
+echo ""
+
+if check_setup "python"; then
+    echo "🐍 [1] Python Demo     - Standard CPU-based ML demos"
+else
+    echo "🐍 [1] Python Demo     - ⚠️  Setup required (run ./start_jupyter.sh first)"
+fi
+
+if check_setup "webgpu"; then
+    echo "⚡ [2] WebGPU Demo     - Browser GPU acceleration"
+else
+    echo "⚡ [2] WebGPU Demo     - ⚠️  Setup required (run ./start_jupyter_webgpu.sh first)"
+fi
+
+if check_setup "rust"; then
+    echo "🦀 [3] Rust Kernel    - Native Rust in Jupyter"
+else
+    echo "🦀 [3] Rust Kernel    - ⚠️  Setup required (run ./quick_start_rust_kernel.sh first)"
+fi
+
+echo ""
+echo "🌐 [4] Online Binder   - Run immediately in browser (no local setup needed)"
+echo "❌ [q] Quit"
+echo ""
+
+read -p "Choose demo type [1-4/q]: " choice
+
+case $choice in
+    1)
+        if check_setup "python"; then
+            echo "🐍 Starting Python demo..."
+            source .venv/bin/activate
+            jupyter lab --port=8888 --no-browser notebooks/rustorch_demo.ipynb
+        else
+            echo "❌ Python environment not found. Run setup first:"
+            echo "   ./start_jupyter.sh"
+            exit 1
+        fi
+        ;;
+    2)
+        if check_setup "webgpu"; then
+            echo "⚡ Starting WebGPU demo..."
+            export JUPYTER_ENABLE_UNSAFE_EXTENSION=1
+            export JUPYTER_CONFIG_DIR="$(pwd)/.jupyter"
+            jupyter lab --port=8888 --no-browser --allow-root --config=.jupyter/jupyter_lab_config.py notebooks/rustorch_webgpu_demo.ipynb
+        else
+            echo "❌ WebGPU setup not found. Run setup first:"
+            echo "   ./start_jupyter_webgpu.sh"
+            exit 1
+        fi
+        ;;
+    3)
+        if check_setup "rust"; then
+            echo "🦀 Starting Rust kernel demo..."
+            jupyter lab --port=8888 --no-browser notebooks/rustorch_rust_kernel_demo.ipynb
+        else
+            echo "❌ Rust kernel not found. Run setup first:"
+            echo "   ./quick_start_rust_kernel.sh"
+            exit 1
+        fi
+        ;;
+    4)
+        echo "🌐 Opening Binder in browser..."
+        if command -v open >/dev/null 2>&1; then
+            open "https://mybinder.org/v2/gh/JunSuzukiJapan/rustorch/main?urlpath=lab"
+        elif command -v xdg-open >/dev/null 2>&1; then
+            xdg-open "https://mybinder.org/v2/gh/JunSuzukiJapan/rustorch/main?urlpath=lab"
+        else
+            echo "Please open this URL in your browser:"
+            echo "https://mybinder.org/v2/gh/JunSuzukiJapan/rustorch/main?urlpath=lab"
+        fi
+        ;;
+    q|Q)
+        echo "👋 Goodbye! / さようなら！"
+        exit 0
+        ;;
+    *)
+        echo "❌ Invalid choice. Please run again and select 1-4 or q."
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Add `start_jupyter_quick.sh` script for fast Jupyter demo restarts
- Interactive menu with automatic setup detection
- Improved README documentation flow for better user experience

## Features
- 🚀 Quick restart launcher with interactive menu
- 🔍 Automatic detection of existing setups (Python venv, WebGPU, Rust kernel)
- 🌐 Support for all demo types (Python, WebGPU, Rust kernel, Binder)
- 🌏 Bilingual support (English/Japanese)
- ⚠️ Graceful error handling with setup guidance

## User Experience Improvements
- Clear separation of "First Time Setup" vs "Quick Restart" workflows
- Better documentation flow explaining when to use which script
- Addresses user request: "次回から簡単に起動する方法はない？"

## Test plan
- [x] Script executes without errors
- [x] Menu displays correctly with setup status detection
- [x] Quit functionality works properly
- [x] README updates are clear and helpful
- [x] All demo types accessible through menu

🤖 Generated with [Claude Code](https://claude.ai/code)