### PR TITLE
Fix one-liner installer hanging on non-interactive mode

### DIFF
--- a/install_jupyter.sh
+++ b/install_jupyter.sh
@@ -188,14 +188,21 @@ main() {
     echo "     GPU最適化された単一環境"
     echo ""
     
-    # Ask user for setup type
+    # Ask user for setup type (auto-select default for non-interactive mode)
     echo "Choose installation type:"
     echo "[1] Hybrid (Default - Python + Rust dual-kernel) ⭐"
     echo "[2] GPU-Optimized ($gpu_specific_strategy)"
     echo "[q] Cancel"
     echo ""
-    read -p "Select [1/2/q] (default: 1): " -n 1 -r
-    echo
+    
+    # Check if running interactively
+    if [[ -t 0 ]]; then
+        read -p "Select [1/2/q] (default: 1): " -n 1 -r
+        echo
+    else
+        echo "Non-interactive mode detected. Auto-selecting default option [1]..."
+        REPLY="1"
+    fi
     
     case $REPLY in
         1|"")


### PR DESCRIPTION
## Summary
- Fix ワンライナーインストーラーが非インタラクティブモードでハングする問題を修正
- Fix one-liner installer hanging when executed via `curl | bash`

## Problem
The one-liner installer in README.md was hanging because:
- `install_jupyter.sh` contains `read` command for user input
- When executed via pipe (`curl | bash`), stdin is not available
- Script would stop at the interactive prompt

READMEのワンライナーインストーラーがハングしていた原因:
- `install_jupyter.sh`にユーザー入力用の`read`コマンドが含まれている
- パイプ経由（`curl | bash`）実行時はstdinが利用できない
- インタラクティブプロンプトでスクリプトが停止

## Solution
- Added non-interactive mode detection using `[[ -t 0 ]]` 
- Auto-select default option (Hybrid) when stdin is not a terminal
- Maintains full interactive functionality when run directly

非インタラクティブモード検出を追加（`[[ -t 0 ]]`使用）
- stdinがターミナルでない場合は自動でデフォルト（Hybrid）選択
- 直接実行時のインタラクティブ機能は完全に維持

## Test Results
✅ Local test passed: `cat install_jupyter.sh | bash`
✅ Shows: "Non-interactive mode detected. Auto-selecting default option [1]..."
✅ Installation completes successfully without user intervention

## Impact
- ✅ One-liner in README now works as expected
- ✅ No breaking changes to existing functionality  
- ✅ Better user experience for quick setup

🤖 Generated with [Claude Code](https://claude.ai/code)