### PR TITLE
feat: synchronize all version references to 0.6.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2454,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "rustorch"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustorch"
-version = "0.6.17"
+version = "0.6.18"
 edition = "2021"
 authors = ["Jun Suzuki <jun.suzuki.japan@gmail.com>"]
 description = "Production-ready PyTorch-compatible deep learning library in Rust with special mathematical functions (gamma, Bessel, error functions), statistical distributions, Fourier transforms (FFT/RFFT), matrix decomposition (SVD/QR/LU/eigenvalue), automatic differentiation, neural networks, computer vision transforms, complete GPU acceleration (CUDA/Metal/OpenCL), SIMD optimizations, parallel processing, WebAssembly browser support, comprehensive distributed learning support, and performance validation"

--- a/jupyter/package.json
+++ b/jupyter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rustorch-jupyter",
-  "version": "0.6.0",
+  "version": "0.6.18",
   "description": "Jupyter Lab integration for RusTorch WASM - Interactive machine learning in browser environments",
   "main": "rustorch_jupyter.js",
   "type": "module",

--- a/notebooks/en/rustorch_rust_kernel_demo_en.ipynb
+++ b/notebooks/en/rustorch_rust_kernel_demo_en.ipynb
@@ -31,7 +31,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": ":dep rustorch = \"0.6.0\"\n:dep ndarray = \"0.16\"\n\n// evcxr configuration\nextern crate rustorch;\nextern crate ndarray;"
+   "source": ":dep rustorch = \"0.6.18\"\n:dep ndarray = \"0.16\"\n\n// evcxr configuration\nextern crate rustorch;\nextern crate ndarray;"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/es/rustorch_rust_kernel_demo_es.ipynb
+++ b/notebooks/es/rustorch_rust_kernel_demo_es.ipynb
@@ -31,7 +31,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": ":dep rustorch = \"0.6.0\"\n:dep ndarray = \"0.16\"\n\n// configuración evcxr\nextern crate rustorch;\nextern crate ndarray;"
+   "source": ":dep rustorch = \"0.6.18\"\n:dep ndarray = \"0.16\"\n\n// configuración evcxr\nextern crate rustorch;\nextern crate ndarray;"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/fr/rustorch_rust_kernel_demo_fr.ipynb
+++ b/notebooks/fr/rustorch_rust_kernel_demo_fr.ipynb
@@ -31,7 +31,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": ":dep rustorch = \"0.6.0\"\n:dep ndarray = \"0.16\"\n\n// configuration evcxr\nextern crate rustorch;\nextern crate ndarray;"
+   "source": ":dep rustorch = \"0.6.18\"\n:dep ndarray = \"0.16\"\n\n// configuration evcxr\nextern crate rustorch;\nextern crate ndarray;"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/it/rustorch_rust_kernel_demo_it.ipynb
+++ b/notebooks/it/rustorch_rust_kernel_demo_it.ipynb
@@ -31,7 +31,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": ":dep rustorch = \"0.6.0\"\n:dep ndarray = \"0.16\"\n\n// configurazione evcxr\nextern crate rustorch;\nextern crate ndarray;"
+   "source": ":dep rustorch = \"0.6.18\"\n:dep ndarray = \"0.16\"\n\n// configurazione evcxr\nextern crate rustorch;\nextern crate ndarray;"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/ko/rustorch_rust_kernel_demo_ko.ipynb
+++ b/notebooks/ko/rustorch_rust_kernel_demo_ko.ipynb
@@ -31,7 +31,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": ":dep rustorch = \"0.6.0\"\n:dep ndarray = \"0.16\"\n\n// evcxr 설정\nextern crate rustorch;\nextern crate ndarray;"
+   "source": ":dep rustorch = \"0.6.18\"\n:dep ndarray = \"0.16\"\n\n// evcxr 설정\nextern crate rustorch;\nextern crate ndarray;"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/rustorch_rust_kernel_demo.ipynb
+++ b/notebooks/rustorch_rust_kernel_demo.ipynb
@@ -29,7 +29,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": ":dep rustorch = \"0.6.0\"\n:dep ndarray = \"0.16\"\n\n// evcxr configuration\nextern crate rustorch;\nextern crate ndarray;"
+   "source": ":dep rustorch = \"0.6.18\"\n:dep ndarray = \"0.16\"\n\n// evcxr configuration\nextern crate rustorch;\nextern crate ndarray;"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/rustorch_rust_kernel_demo_ja.ipynb
+++ b/notebooks/rustorch_rust_kernel_demo_ja.ipynb
@@ -23,7 +23,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": ":dep rustorch = \"0.6.0\"\n:dep ndarray = \"0.16\"\n\n// evcxr用の設定\nextern crate rustorch;\nextern crate ndarray;"
+   "source": ":dep rustorch = \"0.6.18\"\n:dep ndarray = \"0.16\"\n\n// evcxr用の設定\nextern crate rustorch;\nextern crate ndarray;"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/zh/rustorch_rust_kernel_demo_zh.ipynb
+++ b/notebooks/zh/rustorch_rust_kernel_demo_zh.ipynb
@@ -31,7 +31,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": ":dep rustorch = \"0.6.0\"\n:dep ndarray = \"0.16\"\n\n// evcxr配置\nextern crate rustorch;\nextern crate ndarray;"
+   "source": ":dep rustorch = \"0.6.18\"\n:dep ndarray = \"0.16\"\n\n// evcxr配置\nextern crate rustorch;\nextern crate ndarray;"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- Updated main Cargo.toml from 0.6.17 to 0.6.18
- Synchronized all Jupyter notebooks to use rustorch 0.6.18
- Updated jupyter/package.json to version 0.6.18
- Ensured consistent version alignment across all components

## Changes
- **Cargo.toml**: Version bump 0.6.17 → 0.6.18
- **Notebooks**: Updated 8 multilingual notebook files (en, es, fr, it, ko, zh, ja)
- **Jupyter package**: Updated package.json version to 0.6.18
- **Dependencies**: Updated all `:dep rustorch = "0.6.0"` → `"0.6.18"` in notebooks

## Test plan
- [x] Verified version consistency across all files
- [x] Confirmed no other version references need updating
- [x] All changes committed and ready for release

🤖 Generated with [Claude Code](https://claude.ai/code)